### PR TITLE
Allow plugin to use the AWS Profile specified

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -15,14 +15,26 @@ class S3BucketPlugin {
       'sync:buckets': this.sync.bind(this)
     }
   }
+  
+  private getS3Credentials() {
+    let credentials = null;
+    if (this.serverless.service.provider.profile) {
+      credentials = new s3.AWS.SharedIniFileCredentials({
+        profile: this.serverless.service.provider.profile
+      });
+    }
 
+    return credentials;
+  }
+  
   private options () {
     return {
       maxAsyncS3: 20,
       multipartUploadSize: 15728640,
       multipartUploadThreshold: 20971520,
       s3Options: {
-        region: this.serverless.getProvider('aws').getRegion()
+        region: this.serverless.getProvider('aws').getRegion(),
+        credentials: this.getS3Credentials()
       },
       s3RetryCount: 3,
       s3RetryDelay: 1000


### PR DESCRIPTION
Adds a getCredentials() method used in the options() to check if a profile is set in serverless.yml and use it if set, otherwise set credentials to null and fallback to default. Not fully tested.